### PR TITLE
 PassThroughTrackTranscoder supports not checking MediaFormatValidator

### DIFF
--- a/lib/src/main/java/com/otaliastudios/transcoder/engine/TranscoderEngine.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/engine/TranscoderEngine.java
@@ -259,6 +259,9 @@ public class TranscoderEngine {
         TrackTranscoder videoTranscoder = mTranscoders.get(TrackType.VIDEO);
         TrackTranscoder audioTranscoder = mTranscoders.get(TrackType.AUDIO);
         while (!(videoTranscoder.isFinished() && audioTranscoder.isFinished())) {
+            if (Thread.interrupted()) {
+                throw new InterruptedException();
+            }
             boolean stepped = videoTranscoder.transcode() || audioTranscoder.transcode();
             loopCount++;
             if (mDurationUs > 0 && loopCount % PROGRESS_INTERVAL_STEPS == 0) {

--- a/lib/src/main/java/com/otaliastudios/transcoder/transcode/BaseTrackTranscoder.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/transcode/BaseTrackTranscoder.java
@@ -196,7 +196,7 @@ public abstract class BaseTrackTranscoder implements TrackTranscoder {
             throw new RuntimeException("Audio output format changed twice.");
         }
         mActualOutputFormat = format;
-        mMuxer.setOutputFormat(mTrackType, mActualOutputFormat);
+        mMuxer.setOutputFormat(mTrackType, mActualOutputFormat, true);
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/lib/src/main/java/com/otaliastudios/transcoder/transcode/PassThroughTrackTranscoder.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/transcode/PassThroughTrackTranscoder.java
@@ -71,7 +71,7 @@ public class PassThroughTrackTranscoder implements TrackTranscoder {
     public boolean transcode() {
         if (mIsEOS) return false;
         if (!mOutputFormatSet) {
-            mMuxer.setOutputFormat(mTrackType, mOutputFormat);
+            mMuxer.setOutputFormat(mTrackType, mOutputFormat, false);
             mOutputFormatSet = true;
         }
         int trackIndex = mExtractor.getSampleTrackIndex();


### PR DESCRIPTION
Thanks for your sharing. I use this feature in my project. If it is not used here, refuse it.

* PassThroughTrackTranscoder copy track to output mp4 container.  The mimetype of mp4 track is more than just a video/avc, there are other mimetypes. For example, video/hevc, video/mp    4v-es... and so on. So PassThroughTrackTranscoder#getDeterminedFormat() returns null to prevent checking MediaFormatValidator.