### PR TITLE
Fix Xamarin Incompatibility

### DIFF
--- a/lib/src/main/java/com/otaliastudios/transcoder/source/FileDescriptorDataSource.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/source/FileDescriptorDataSource.java
@@ -21,12 +21,12 @@ public class FileDescriptorDataSource extends DefaultDataSource {
     }
 
     @Override
-    public void applyExtractor(@NonNull MediaExtractor extractor) throws IOException  {
+    protected void applyExtractor(@NonNull MediaExtractor extractor) throws IOException  {
         extractor.setDataSource(descriptor);
     }
 
     @Override
-    public void applyRetriever(@NonNull MediaMetadataRetriever retriever) {
+    protected void applyRetriever(@NonNull MediaMetadataRetriever retriever) {
         retriever.setDataSource(descriptor);
     }
 }

--- a/lib/src/main/java/com/otaliastudios/transcoder/source/FilePathDataSource.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/source/FilePathDataSource.java
@@ -46,13 +46,13 @@ public class FilePathDataSource extends DefaultDataSource {
     }
 
     @Override
-    public void applyExtractor(@NonNull MediaExtractor extractor) throws IOException {
+    protected void applyExtractor(@NonNull MediaExtractor extractor) throws IOException {
         ensureDescriptorSource();
         mDescriptorSource.applyExtractor(extractor);
     }
 
     @Override
-    public void applyRetriever(@NonNull MediaMetadataRetriever retriever) {
+    protected void applyRetriever(@NonNull MediaMetadataRetriever retriever) {
         ensureDescriptorSource();
         mDescriptorSource.applyRetriever(retriever);
     }

--- a/lib/src/main/java/com/otaliastudios/transcoder/source/UriDataSource.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/source/UriDataSource.java
@@ -24,12 +24,12 @@ public class UriDataSource extends DefaultDataSource {
     }
 
     @Override
-    public void applyExtractor(@NonNull MediaExtractor extractor) throws IOException  {
+    protected void applyExtractor(@NonNull MediaExtractor extractor) throws IOException  {
         extractor.setDataSource(context, uri, null);
     }
 
     @Override
-    public void applyRetriever(@NonNull MediaMetadataRetriever retriever) {
+    protected void applyRetriever(@NonNull MediaMetadataRetriever retriever) {
         retriever.setDataSource(context, uri);
     }
 }


### PR DESCRIPTION
Fix Xamarin Incompatibility

When I try to convert the library to Xamarin, I have a small issue with access modifiers.  I think C# is a little more strict than java on this, but the issue is that if an abstract method is protected, an override must be protected or private.  It can't be made public.  In the Transcoder library, DefaultDataSource.applyExtractor and DefaultDataSource.applyRetriever are protected, but all the overrides are public.  This PR makes the base class abstract methods public to remove the issue.