### PR TITLE
Enable multiple video tracks with no audio.

### DIFF
--- a/lib/src/main/java/com/otaliastudios/transcoder/engine/Engine.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/engine/Engine.java
@@ -119,12 +119,16 @@ public class Engine {
                 MediaFormat inputFormat = source.getTrackFormat(type);
                 if (inputFormat != null) {
                     inputFormats.add(provider.provideMediaFormat(source, type, inputFormat));
-                } else if (sources.size() > 1) {
-                    throw new IllegalArgumentException("More than one source selected for type " + type
-                            + ", but getTrackFormat returned null.");
                 }
             }
-            status = strategy.createOutputFormat(inputFormats, outputFormat);
+
+            if (inputFormats.size() == sources.size()) {
+                status = strategy.createOutputFormat(inputFormats, outputFormat);
+            } else if (!inputFormats.isEmpty()) {
+                throw new IllegalArgumentException("getTrackFormat returned null for " +
+                        (sources.size()-inputFormats.size()) + "/"  + sources.size() +
+                        " sources off " + type);
+            }
         }
         mOutputFormats.set(type, outputFormat);
         mDataSink.setTrackStatus(type, status);


### PR DESCRIPTION
There's always a number of audio sources equal to the number of video sources (TranscoderOptions.java:131)
and getTrackFormat returns null when the video file had no audio track or vice versa.
So when getTrackFormat  returns null for all sources we can remove the associated track
type.

If only some of the data source files have no audio or video sources then it will still throw
an exception because we can't build a valid stream with missing parts.: it is either a full
track or no track.