### PR TITLE
Feature/muted audio fixes #51

### DIFF
--- a/lib/src/main/java/com/otaliastudios/transcoder/TranscoderOptions.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/TranscoderOptions.java
@@ -13,7 +13,7 @@ import com.otaliastudios.transcoder.sink.DefaultDataSink;
 import com.otaliastudios.transcoder.source.DataSource;
 import com.otaliastudios.transcoder.source.FileDescriptorDataSource;
 import com.otaliastudios.transcoder.source.FilePathDataSource;
-import com.otaliastudios.transcoder.source.MutedAudioDataSource;
+import com.otaliastudios.transcoder.source.BlankAudioDataSource;
 import com.otaliastudios.transcoder.source.UriDataSource;
 import com.otaliastudios.transcoder.strategy.DefaultAudioStrategy;
 import com.otaliastudios.transcoder.strategy.DefaultVideoStrategies;
@@ -349,7 +349,7 @@ public class TranscoderOptions {
                 if (dataSource.getTrackFormat(TrackType.AUDIO) != null) {
                     result.add(dataSource);
                 } else {
-                    result.add(new MutedAudioDataSource(dataSource.getDurationUs()));
+                    result.add(new BlankAudioDataSource(dataSource.getDurationUs()));
                 }
             }
             return result;

--- a/lib/src/main/java/com/otaliastudios/transcoder/TranscoderOptions.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/TranscoderOptions.java
@@ -13,7 +13,7 @@ import com.otaliastudios.transcoder.sink.DefaultDataSink;
 import com.otaliastudios.transcoder.source.DataSource;
 import com.otaliastudios.transcoder.source.FileDescriptorDataSource;
 import com.otaliastudios.transcoder.source.FilePathDataSource;
-import com.otaliastudios.transcoder.source.TrimDataSource;
+import com.otaliastudios.transcoder.source.MutedAudioDataSource;
 import com.otaliastudios.transcoder.source.UriDataSource;
 import com.otaliastudios.transcoder.strategy.DefaultAudioStrategy;
 import com.otaliastudios.transcoder.strategy.DefaultVideoStrategies;
@@ -129,7 +129,11 @@ public class TranscoderOptions {
         @NonNull
         @SuppressWarnings("WeakerAccess")
         public Builder addDataSource(@NonNull DataSource dataSource) {
-            audioDataSources.add(dataSource);
+            if (dataSource.getTrackFormat(TrackType.AUDIO) == null && dataSource.getTrackFormat(TrackType.VIDEO) != null) {
+                audioDataSources.add(new MutedAudioDataSource(dataSource.getDurationUs()));
+            } else {
+                audioDataSources.add(dataSource);
+            }
             videoDataSources.add(dataSource);
             return this;
         }

--- a/lib/src/main/java/com/otaliastudios/transcoder/internal/MediaFormatConstants.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/internal/MediaFormatConstants.java
@@ -53,6 +53,7 @@ public class MediaFormatConstants {
     // Audio formats
     // from MediaFormat of API level >= 21
     public static final String MIMETYPE_AUDIO_AAC = "audio/mp4a-latm";
+    public static final String MIMETYPE_AUDIO_RAW = "audio/raw";
 
     private MediaFormatConstants() { }
 }

--- a/lib/src/main/java/com/otaliastudios/transcoder/source/BlankAudioDataSource.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/source/BlankAudioDataSource.java
@@ -17,8 +17,8 @@ import static com.otaliastudios.transcoder.internal.MediaFormatConstants.MIMETYP
  * This class can be used to concatenate a DataSources that has a video track only with another
  * that has both video and audio track.
  */
-public class MutedAudioDataSource implements DataSource {
-    private final static String TAG = MutedAudioDataSource.class.getSimpleName();
+public class BlankAudioDataSource implements DataSource {
+    private final static String TAG = BlankAudioDataSource.class.getSimpleName();
 
     private static final int CHANNEL_COUNT = 2;
     private static final int SAMPLE_RATE = 44100;
@@ -35,7 +35,7 @@ public class MutedAudioDataSource implements DataSource {
 
     private long currentTimestampUs = 0L;
 
-    public MutedAudioDataSource(long durationUs) {
+    public BlankAudioDataSource(long durationUs) {
         this.durationUs = durationUs;
         this.byteBuffer = ByteBuffer.allocateDirect(PERIOD_SIZE).order(ByteOrder.nativeOrder());
         this.audioFormat = new MediaFormat();
@@ -81,7 +81,7 @@ public class MutedAudioDataSource implements DataSource {
 
     @Override
     public boolean canReadTrack(@NonNull TrackType type) {
-        return (type == TrackType.AUDIO) && !isDrained();
+        return type == TrackType.AUDIO;
     }
 
     @Override

--- a/lib/src/main/java/com/otaliastudios/transcoder/source/MutedAudioDataSource.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/source/MutedAudioDataSource.java
@@ -21,24 +21,28 @@ public class MutedAudioDataSource implements DataSource {
     private final static String TAG = MutedAudioDataSource.class.getSimpleName();
 
     private static final int CHANNEL_COUNT = 2;
-    private static final int BIT_RATE = 64000;
-    private final static int SAMPLE_RATE = 48000;
-    private final static int BUFFER_SIZE = 65536; // Lower values are ignored
-    private final static int PERIOD_SIZE = BUFFER_SIZE * CHANNEL_COUNT / 32;
-    private final static long PERIOD_TIME = 21333;
+    private static final int SAMPLE_RATE = 44100;
+    private static final int BITS_PER_SAMPLE = 16;
+    private static final int BIT_RATE = CHANNEL_COUNT * SAMPLE_RATE * BITS_PER_SAMPLE;
+    private static final int SAMPLES_PER_PERIOD = 2048;
+    private static final double PERIOD_TIME_SECONDS = (double) SAMPLES_PER_PERIOD / SAMPLE_RATE;
+    private static final long PERIOD_TIME_US = (long) (1000000 * PERIOD_TIME_SECONDS);
+    private static final int PERIOD_SIZE = (int) (PERIOD_TIME_SECONDS * BIT_RATE / 8);
 
-    private final MediaFormat audioFormat;
     private final long durationUs;
+    private final ByteBuffer byteBuffer;
+    private final MediaFormat audioFormat;
 
-    private long mCurrentTimestampUs = 0L;
+    private long currentTimestampUs = 0L;
 
     public MutedAudioDataSource(Long durationUs) {
         this.durationUs = durationUs;
+        this.byteBuffer = ByteBuffer.allocateDirect(PERIOD_SIZE).order(ByteOrder.nativeOrder());
         this.audioFormat = new MediaFormat();
         audioFormat.setString(MediaFormat.KEY_MIME, MIMETYPE_AUDIO_RAW);
         audioFormat.setInteger(MediaFormat.KEY_BIT_RATE, BIT_RATE);
         audioFormat.setInteger(MediaFormat.KEY_CHANNEL_COUNT, CHANNEL_COUNT);
-        audioFormat.setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, BUFFER_SIZE);
+        audioFormat.setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, PERIOD_SIZE);
         audioFormat.setInteger(MediaFormat.KEY_SAMPLE_RATE, SAMPLE_RATE);
     }
 
@@ -81,27 +85,28 @@ public class MutedAudioDataSource implements DataSource {
 
     @Override
     public void readTrack(@NonNull Chunk chunk) {
-        chunk.buffer = ByteBuffer.allocateDirect(BUFFER_SIZE).order(ByteOrder.nativeOrder());
+        byteBuffer.clear();
+        chunk.buffer = byteBuffer;
         chunk.isKeyFrame = true;
         if (isDrained()) {
             chunk.timestampUs = 0;
             chunk.bytes = -1;
         } else {
-            chunk.timestampUs = mCurrentTimestampUs;
+            chunk.timestampUs = currentTimestampUs;
             chunk.bytes = PERIOD_SIZE;
         }
 
-        mCurrentTimestampUs += PERIOD_TIME;
+        currentTimestampUs += PERIOD_TIME_US;
     }
 
     @Override
     public long getReadUs() {
-        return mCurrentTimestampUs;
+        return currentTimestampUs;
     }
 
     @Override
     public boolean isDrained() {
-        return mCurrentTimestampUs >= getDurationUs();
+        return currentTimestampUs >= getDurationUs();
     }
 
     @Override
@@ -111,6 +116,6 @@ public class MutedAudioDataSource implements DataSource {
 
     @Override
     public void rewind() {
-        // Nothing to do
+        currentTimestampUs = 0;
     }
 }

--- a/lib/src/main/java/com/otaliastudios/transcoder/source/MutedAudioDataSource.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/source/MutedAudioDataSource.java
@@ -24,8 +24,8 @@ public class MutedAudioDataSource implements DataSource {
     private static final int SAMPLE_RATE = 44100;
     private static final int BITS_PER_SAMPLE = 16;
     private static final int BIT_RATE = CHANNEL_COUNT * SAMPLE_RATE * BITS_PER_SAMPLE;
-    private static final int SAMPLES_PER_PERIOD = 2048;
-    private static final double PERIOD_TIME_SECONDS = (double) SAMPLES_PER_PERIOD / SAMPLE_RATE;
+    private static final double SAMPLES_PER_PERIOD = 2048;
+    private static final double PERIOD_TIME_SECONDS = SAMPLES_PER_PERIOD / SAMPLE_RATE;
     private static final long PERIOD_TIME_US = (long) (1000000 * PERIOD_TIME_SECONDS);
     private static final int PERIOD_SIZE = (int) (PERIOD_TIME_SECONDS * BIT_RATE / 8);
 
@@ -35,7 +35,7 @@ public class MutedAudioDataSource implements DataSource {
 
     private long currentTimestampUs = 0L;
 
-    public MutedAudioDataSource(Long durationUs) {
+    public MutedAudioDataSource(long durationUs) {
         this.durationUs = durationUs;
         this.byteBuffer = ByteBuffer.allocateDirect(PERIOD_SIZE).order(ByteOrder.nativeOrder());
         this.audioFormat = new MediaFormat();
@@ -75,7 +75,8 @@ public class MutedAudioDataSource implements DataSource {
 
     @Override
     public long seekTo(long desiredTimestampUs) {
-        return (desiredTimestampUs <= durationUs) ? desiredTimestampUs : -1;
+        currentTimestampUs = desiredTimestampUs;
+        return desiredTimestampUs;
     }
 
     @Override
@@ -88,13 +89,8 @@ public class MutedAudioDataSource implements DataSource {
         byteBuffer.clear();
         chunk.buffer = byteBuffer;
         chunk.isKeyFrame = true;
-        if (isDrained()) {
-            chunk.timestampUs = 0;
-            chunk.bytes = -1;
-        } else {
-            chunk.timestampUs = currentTimestampUs;
-            chunk.bytes = PERIOD_SIZE;
-        }
+        chunk.timestampUs = currentTimestampUs;
+        chunk.bytes = PERIOD_SIZE;
 
         currentTimestampUs += PERIOD_TIME_US;
     }

--- a/lib/src/main/java/com/otaliastudios/transcoder/source/MutedAudioDataSource.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/source/MutedAudioDataSource.java
@@ -1,0 +1,116 @@
+package com.otaliastudios.transcoder.source;
+
+import android.media.MediaFormat;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.otaliastudios.transcoder.engine.TrackType;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import static com.otaliastudios.transcoder.internal.MediaFormatConstants.MIMETYPE_AUDIO_RAW;
+
+/**
+ * A {@link DataSource} that provides a silent audio track of the a specific duration.
+ * This class can be used to concatenate a DataSources that has a video track only with another
+ * that has both video and audio track.
+ */
+public class MutedAudioDataSource implements DataSource {
+    private final static String TAG = MutedAudioDataSource.class.getSimpleName();
+
+    private static final int CHANNEL_COUNT = 2;
+    private static final int BIT_RATE = 64000;
+    private final static int SAMPLE_RATE = 48000;
+    private final static int BUFFER_SIZE = 65536; // Lower values are ignored
+    private final static int PERIOD_SIZE = BUFFER_SIZE * CHANNEL_COUNT / 32;
+    private final static long PERIOD_TIME = 21333;
+
+    private final MediaFormat audioFormat;
+    private final long durationUs;
+
+    private long mCurrentTimestampUs = 0L;
+
+    public MutedAudioDataSource(Long durationUs) {
+        this.durationUs = durationUs;
+        this.audioFormat = new MediaFormat();
+        audioFormat.setString(MediaFormat.KEY_MIME, MIMETYPE_AUDIO_RAW);
+        audioFormat.setInteger(MediaFormat.KEY_BIT_RATE, BIT_RATE);
+        audioFormat.setInteger(MediaFormat.KEY_CHANNEL_COUNT, CHANNEL_COUNT);
+        audioFormat.setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, BUFFER_SIZE);
+        audioFormat.setInteger(MediaFormat.KEY_SAMPLE_RATE, SAMPLE_RATE);
+    }
+
+    @Override
+    public int getOrientation() {
+        return 0;
+    }
+
+    @Nullable
+    @Override
+    public double[] getLocation() {
+        return null;
+    }
+
+    @Override
+    public long getDurationUs() {
+        return durationUs;
+    }
+
+    @Nullable
+    @Override
+    public MediaFormat getTrackFormat(@NonNull TrackType type) {
+        return (type == TrackType.AUDIO) ? audioFormat : null;
+    }
+
+    @Override
+    public void selectTrack(@NonNull TrackType type) {
+        // Nothing to do
+    }
+
+    @Override
+    public long seekTo(long desiredTimestampUs) {
+        return (desiredTimestampUs <= durationUs) ? desiredTimestampUs : -1;
+    }
+
+    @Override
+    public boolean canReadTrack(@NonNull TrackType type) {
+        return (type == TrackType.AUDIO) && !isDrained();
+    }
+
+    @Override
+    public void readTrack(@NonNull Chunk chunk) {
+        chunk.buffer = ByteBuffer.allocateDirect(BUFFER_SIZE).order(ByteOrder.nativeOrder());
+        chunk.isKeyFrame = true;
+        if (isDrained()) {
+            chunk.timestampUs = 0;
+            chunk.bytes = -1;
+        } else {
+            chunk.timestampUs = mCurrentTimestampUs;
+            chunk.bytes = PERIOD_SIZE;
+        }
+
+        mCurrentTimestampUs += PERIOD_TIME;
+    }
+
+    @Override
+    public long getReadUs() {
+        return mCurrentTimestampUs;
+    }
+
+    @Override
+    public boolean isDrained() {
+        return mCurrentTimestampUs >= getDurationUs();
+    }
+
+    @Override
+    public void releaseTrack(@NonNull TrackType type) {
+        // Nothing to do
+    }
+
+    @Override
+    public void rewind() {
+        // Nothing to do
+    }
+}


### PR DESCRIPTION
Hi Mattia,
This PR solves the problem I was facing when concatenating two dataSources where one would have audio+video tracks and the other would have a video track only (no audio track).
The new `MutedAudioDataSource` provides a silent sound track, which allows the concatenation to go on correctly.
How would you prefer to do the check that triggers the use of this new DataSource? Initially I thought it could be an AudioStrategy, or a builder option. For now (wip), I've added it in `Builder.addDataSource(dataSource)` by default, and it can be skipped by using `Builder.addDataSource(track, dataSource)`.
I did many tests with the audio format values (bufferSize, periodSize, periodTime) and these values are the ones that worked for me :100: 
thanks :)