### PR TITLE
Adds a way to manipulate the raw audio data for a specific DataSource…

### DIFF
--- a/lib/src/main/java/com/otaliastudios/transcoder/engine/Engine.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/engine/Engine.java
@@ -20,6 +20,7 @@ import android.media.MediaFormat;
 import com.otaliastudios.transcoder.TranscoderOptions;
 import com.otaliastudios.transcoder.internal.TrackTypeMap;
 import com.otaliastudios.transcoder.internal.ValidatorException;
+import com.otaliastudios.transcoder.postprocessor.AudioPostProcessor;
 import com.otaliastudios.transcoder.sink.DataSink;
 import com.otaliastudios.transcoder.sink.InvalidOutputFormatException;
 import com.otaliastudios.transcoder.source.DataSource;
@@ -177,7 +178,8 @@ public class Engine {
                         transcoder = new AudioTrackTranscoder(dataSource, mDataSink,
                                 interpolator,
                                 options.getAudioStretcher(),
-                                options.getAudioResampler());
+                                options.getAudioResampler(),
+                                (AudioPostProcessor)dataSource.getPostProcessor());
                         break;
                     default:
                         throw new RuntimeException("Unknown type: " + type);

--- a/lib/src/main/java/com/otaliastudios/transcoder/postprocessor/AudioPostProcessor.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/postprocessor/AudioPostProcessor.java
@@ -1,0 +1,9 @@
+package com.otaliastudios.transcoder.postprocessor;
+
+import androidx.annotation.NonNull;
+
+import java.nio.ShortBuffer;
+
+public interface AudioPostProcessor extends PostProcessor {
+    void postProcess(@NonNull final ShortBuffer inputBuffer, @NonNull final ShortBuffer outputBuffer);
+}

--- a/lib/src/main/java/com/otaliastudios/transcoder/postprocessor/MixerSourceAudioPostProcessor.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/postprocessor/MixerSourceAudioPostProcessor.java
@@ -1,0 +1,22 @@
+package com.otaliastudios.transcoder.postprocessor;
+
+import androidx.annotation.NonNull;
+
+import java.nio.ShortBuffer;
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+public class MixerSourceAudioPostProcessor implements AudioPostProcessor {
+
+    Queue<ShortBuffer> mBuffers = new ArrayDeque<>();
+
+    @Override
+    public void postProcess(@NonNull ShortBuffer inputBuffer, @NonNull ShortBuffer outputBuffer) {
+        if (inputBuffer.remaining() > 0) {
+            ShortBuffer sourceBuffer = ShortBuffer.allocate(inputBuffer.capacity());
+            sourceBuffer.put(inputBuffer);
+            sourceBuffer.rewind();
+            mBuffers.add(sourceBuffer);
+        }
+    }
+}

--- a/lib/src/main/java/com/otaliastudios/transcoder/postprocessor/MixerTargetAudioPostProcessor.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/postprocessor/MixerTargetAudioPostProcessor.java
@@ -1,0 +1,48 @@
+package com.otaliastudios.transcoder.postprocessor;
+
+import androidx.annotation.NonNull;
+
+import java.nio.ShortBuffer;
+
+import static java.lang.Math.min;
+
+public class MixerTargetAudioPostProcessor implements AudioPostProcessor {
+    private MixerSourceAudioPostProcessor mSource;
+    private float mSourceVolume;
+    private float mTargetVolume;
+
+    public MixerTargetAudioPostProcessor(MixerSourceAudioPostProcessor source, float sourceVolume, float targetVolume)
+    {
+        mSource = source;
+        mSourceVolume = sourceVolume;
+        mTargetVolume = targetVolume;
+    }
+
+    private short mixSamples(short sourceSample, short targetSample) {
+        float mixedSample = (sourceSample * mSourceVolume)  + (targetSample * mTargetVolume);
+        if (mixedSample < Short.MIN_VALUE)
+            mixedSample = Short.MIN_VALUE;
+        else if (mixedSample > Short.MAX_VALUE)
+            mixedSample = Short.MAX_VALUE;
+        return (short)mixedSample;
+    }
+
+    @Override
+    public void postProcess(@NonNull ShortBuffer inputBuffer, @NonNull ShortBuffer outputBuffer) {
+        ShortBuffer sourceBuffer = mSource.mBuffers.peek();
+        int inputRemaining = inputBuffer.remaining();
+        while (sourceBuffer != null && inputRemaining > 0) {
+            int sourceRemaining = sourceBuffer.remaining();
+            int remaining = min(inputRemaining, sourceRemaining);
+            for (int i=0; i<remaining; i++) {
+                outputBuffer.put(mixSamples(sourceBuffer.get(), inputBuffer.get()));
+            }
+            inputRemaining -= sourceRemaining;
+            if (inputRemaining >= 0) {
+                mSource.mBuffers.remove();
+                sourceBuffer = mSource.mBuffers.peek();
+            }
+        }
+        outputBuffer.put(inputBuffer);
+    }
+}

--- a/lib/src/main/java/com/otaliastudios/transcoder/postprocessor/PostProcessor.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/postprocessor/PostProcessor.java
@@ -1,0 +1,4 @@
+package com.otaliastudios.transcoder.postprocessor;
+
+public interface PostProcessor {
+}

--- a/lib/src/main/java/com/otaliastudios/transcoder/postprocessor/VolumeAudioPostProcessor.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/postprocessor/VolumeAudioPostProcessor.java
@@ -1,0 +1,30 @@
+package com.otaliastudios.transcoder.postprocessor;
+
+import androidx.annotation.NonNull;
+
+import java.nio.ShortBuffer;
+
+public class VolumeAudioPostProcessor implements AudioPostProcessor {
+    float mVolume;
+
+    public VolumeAudioPostProcessor(float volume) {
+        mVolume = volume;
+    }
+
+    private short applyVolume(short sample) {
+        float sampleAtVolume = sample * mVolume;
+        if (sampleAtVolume < Short.MIN_VALUE)
+            sampleAtVolume = Short.MIN_VALUE;
+        else if (sampleAtVolume > Short.MAX_VALUE)
+            sampleAtVolume = Short.MAX_VALUE;
+        return (short)sampleAtVolume;
+    }
+
+    @Override
+    public void postProcess(@NonNull ShortBuffer inputBuffer, @NonNull ShortBuffer outputBuffer) {
+        int inputRemaining = inputBuffer.remaining();
+        for (int i=0; i<inputRemaining; i++) {
+            outputBuffer.put(applyVolume(inputBuffer.get()));
+        }
+    }
+}

--- a/lib/src/main/java/com/otaliastudios/transcoder/source/BlankAudioDataSource.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/source/BlankAudioDataSource.java
@@ -6,6 +6,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.otaliastudios.transcoder.engine.TrackType;
+import com.otaliastudios.transcoder.postprocessor.PostProcessor;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -44,6 +45,18 @@ public class BlankAudioDataSource implements DataSource {
         audioFormat.setInteger(MediaFormat.KEY_CHANNEL_COUNT, CHANNEL_COUNT);
         audioFormat.setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, PERIOD_SIZE);
         audioFormat.setInteger(MediaFormat.KEY_SAMPLE_RATE, SAMPLE_RATE);
+    }
+
+    private PostProcessor postProcessor = null;
+
+    @Override
+    public void setPostProcessor(PostProcessor postProcessor) {
+        this.postProcessor = postProcessor;
+    }
+
+    @Override
+    public PostProcessor getPostProcessor() {
+        return postProcessor;
     }
 
     @Override

--- a/lib/src/main/java/com/otaliastudios/transcoder/source/DataSource.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/source/DataSource.java
@@ -6,6 +6,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.otaliastudios.transcoder.engine.TrackType;
+import com.otaliastudios.transcoder.postprocessor.PostProcessor;
 
 import java.nio.ByteBuffer;
 
@@ -13,6 +14,22 @@ import java.nio.ByteBuffer;
  * Represents the source of input data.
  */
 public interface DataSource {
+
+    /**
+     * Returns an handler that need to be executed with the raw data source data
+     * before that it gets encoded.
+     *
+     * @return the PostProcessor object
+     */
+    PostProcessor getPostProcessor();
+
+    /**
+     * Sets the handler that needs to be called before that the raw data source data
+     * gets sent to the encoder.
+     *
+     * @param postProcessor the PostProcessor object
+     */
+    void setPostProcessor(PostProcessor postProcessor);
 
     /**
      * Metadata information. Returns the video orientation, or 0.

--- a/lib/src/main/java/com/otaliastudios/transcoder/source/DataSourceWrapper.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/source/DataSourceWrapper.java
@@ -7,6 +7,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.otaliastudios.transcoder.engine.TrackType;
+import com.otaliastudios.transcoder.postprocessor.PostProcessor;
 
 /**
  * A {@link DataSource} wrapper that simply delegates all methods to the
@@ -24,6 +25,18 @@ public class DataSourceWrapper implements DataSource {
     @NonNull
     protected DataSource getSource() {
         return mSource;
+    }
+
+    private PostProcessor postProcessor = null;
+
+    @Override
+    public void setPostProcessor(PostProcessor postProcessor) {
+        this.postProcessor = postProcessor;
+    }
+
+    @Override
+    public PostProcessor getPostProcessor() {
+        return postProcessor;
     }
 
     @Override

--- a/lib/src/main/java/com/otaliastudios/transcoder/source/DefaultDataSource.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/source/DefaultDataSource.java
@@ -12,6 +12,7 @@ import com.otaliastudios.transcoder.engine.TrackType;
 import com.otaliastudios.transcoder.internal.ISO6709LocationParser;
 import com.otaliastudios.transcoder.internal.Logger;
 import com.otaliastudios.transcoder.internal.TrackTypeMap;
+import com.otaliastudios.transcoder.postprocessor.PostProcessor;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -57,6 +58,18 @@ public abstract class DefaultDataSource implements DataSource {
     protected abstract void applyExtractor(@NonNull MediaExtractor extractor) throws IOException;
 
     protected abstract void applyRetriever(@NonNull MediaMetadataRetriever retriever);
+
+    private PostProcessor postProcessor = null;
+
+    @Override
+    public void setPostProcessor(PostProcessor postProcessor) {
+        this.postProcessor = postProcessor;
+    }
+
+    @Override
+    public PostProcessor getPostProcessor() {
+        return postProcessor;
+    }
 
     @Override
     public void selectTrack(@NonNull TrackType type) {

--- a/lib/src/main/java/com/otaliastudios/transcoder/transcode/AudioTrackTranscoder.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/transcode/AudioTrackTranscoder.java
@@ -8,6 +8,7 @@ import androidx.annotation.NonNull;
 
 import com.otaliastudios.transcoder.engine.TrackType;
 import com.otaliastudios.transcoder.internal.MediaCodecBuffers;
+import com.otaliastudios.transcoder.postprocessor.AudioPostProcessor;
 import com.otaliastudios.transcoder.resample.AudioResampler;
 import com.otaliastudios.transcoder.sink.DataSink;
 import com.otaliastudios.transcoder.source.DataSource;
@@ -22,6 +23,7 @@ public class AudioTrackTranscoder extends BaseTrackTranscoder {
     private TimeInterpolator mTimeInterpolator;
     private AudioStretcher mAudioStretcher;
     private AudioResampler mAudioResampler;
+    private AudioPostProcessor mAudioPostProcessor;
     private AudioEngine mAudioEngine;
     private MediaCodec mEncoder; // to create the channel
     private MediaFormat mEncoderOutputFormat; // to create the channel
@@ -30,11 +32,13 @@ public class AudioTrackTranscoder extends BaseTrackTranscoder {
                                 @NonNull DataSink dataSink,
                                 @NonNull TimeInterpolator timeInterpolator,
                                 @NonNull AudioStretcher audioStretcher,
-                                @NonNull AudioResampler audioResampler) {
+                                @NonNull AudioResampler audioResampler,
+                                @NonNull AudioPostProcessor audioPostProcessor) {
         super(dataSource, dataSink, TrackType.AUDIO);
         mTimeInterpolator = timeInterpolator;
         mAudioStretcher = audioStretcher;
         mAudioResampler = audioResampler;
+        mAudioPostProcessor = audioPostProcessor;
     }
 
     @Override
@@ -57,7 +61,8 @@ public class AudioTrackTranscoder extends BaseTrackTranscoder {
                 mEncoder, mEncoderOutputFormat,
                 mTimeInterpolator,
                 mAudioStretcher,
-                mAudioResampler);
+                mAudioResampler,
+                mAudioPostProcessor);
         mEncoder = null;
         mEncoderOutputFormat = null;
         mTimeInterpolator = null;


### PR DESCRIPTION
… before that it gets encoded.

DataSources now have an optional handler: "PostProcessor" that will be called for each input and output buffers, just like the resample ore remix classes, but the goal in this case is to do a custom manipulation of the final raw data. It can also be use to prevent the data from being sent to the encoder (by not not filling the outputBuffer in the postProcess method) . For example, it can be use to merge two audio DataSource.