### PR TITLE
DataSink, added fileDescriptor support

### DIFF
--- a/lib/src/main/java/com/otaliastudios/transcoder/Transcoder.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/Transcoder.java
@@ -15,6 +15,7 @@
  */
 package com.otaliastudios.transcoder;
 
+import android.os.Build;
 import android.os.Handler;
 
 import com.otaliastudios.transcoder.engine.Engine;
@@ -24,6 +25,7 @@ import com.otaliastudios.transcoder.internal.Logger;
 import com.otaliastudios.transcoder.validator.Validator;
 import com.otaliastudios.transcoder.internal.ValidatorException;
 
+import java.io.FileDescriptor;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -33,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 
 public class Transcoder {
     private static final String TAG = Transcoder.class.getSimpleName();
@@ -97,6 +100,19 @@ public class Transcoder {
     @NonNull
     public static TranscoderOptions.Builder into(@NonNull String outPath) {
         return new TranscoderOptions.Builder(outPath);
+    }
+
+    /**
+     * Starts building transcoder options.
+     * Requires a non null fileDescriptor to the output file or stream
+     *
+     * @param fileDescriptor descriptor of the output file or stream
+     * @return an options builder
+     */
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    @NonNull
+    public static TranscoderOptions.Builder into(@NonNull FileDescriptor fileDescriptor) {
+        return new TranscoderOptions.Builder(fileDescriptor);
     }
 
     /**

--- a/lib/src/main/java/com/otaliastudios/transcoder/TranscoderOptions.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/TranscoderOptions.java
@@ -2,6 +2,7 @@ package com.otaliastudios.transcoder;
 
 import android.content.Context;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 
@@ -33,6 +34,7 @@ import java.util.concurrent.Future;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 
 /**
  * Collects transcoding options consumed by {@link Transcoder}.
@@ -120,6 +122,11 @@ public class TranscoderOptions {
 
         Builder(@NonNull String outPath) {
             this.dataSink = new DefaultDataSink(outPath);
+        }
+
+        @RequiresApi(api = Build.VERSION_CODES.O)
+        Builder(@NonNull FileDescriptor fileDescriptor) {
+            this.dataSink = new DefaultDataSink(fileDescriptor);
         }
 
         Builder(@NonNull DataSink dataSink) {

--- a/lib/src/main/java/com/otaliastudios/transcoder/sink/DefaultDataSink.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/sink/DefaultDataSink.java
@@ -6,12 +6,14 @@ import android.media.MediaMuxer;
 import android.os.Build;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 
 import com.otaliastudios.transcoder.engine.TrackStatus;
 import com.otaliastudios.transcoder.engine.TrackType;
 import com.otaliastudios.transcoder.internal.TrackTypeMap;
 import com.otaliastudios.transcoder.internal.Logger;
 
+import java.io.FileDescriptor;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -69,6 +71,21 @@ public class DefaultDataSink implements DataSink {
     public DefaultDataSink(@NonNull String outputFilePath, int format) {
         try {
             mMuxer = new MediaMuxer(outputFilePath, format);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    public DefaultDataSink(@NonNull FileDescriptor fileDescriptor) {
+        this(fileDescriptor, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4);
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    @SuppressWarnings("WeakerAccess")
+    public DefaultDataSink(@NonNull FileDescriptor fileDescriptor, int format) {
+        try {
+            mMuxer = new MediaMuxer(fileDescriptor, format);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
I've added 2 constructors with `FileDescription` param, similar to the existing ones that use `outputFilePath`. The other option would be to replace the 4 constructors by one that uses a `MediaMuxer`.