### PR TITLE
Added support for custom postprocessing

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/lib/src/main/java/com/otaliastudios/transcoder/TranscoderOptions.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/TranscoderOptions.java
@@ -335,6 +335,19 @@ public class TranscoderOptions {
         }
 
         /**
+         * Sets an {@link DecoderIOFactory} to provide decoder input and output.
+         * Can be use to implement custom video postprocessing
+         * Defaults to {@link DefaultAudioResampler}.
+         *
+         * @param decoderIOFactory a decoder io factory
+         * @return this for chaining
+         */
+        public Builder setDecoderIOFactory(DecoderIOFactory decoderIOFactory) {
+            this.decoderIOFactory = decoderIOFactory;
+            return this;
+        }
+
+        /**
          * Generates muted audio data sources if needed
          * @return The list of audio data sources including the muted sources
          */

--- a/lib/src/main/java/com/otaliastudios/transcoder/TranscoderOptions.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/TranscoderOptions.java
@@ -7,6 +7,8 @@ import android.os.Handler;
 import android.os.Looper;
 
 import com.otaliastudios.transcoder.engine.TrackType;
+import com.otaliastudios.transcoder.io_factory.DecoderIOFactory;
+import com.otaliastudios.transcoder.io_factory.DefaultDecoderIOFactory;
 import com.otaliastudios.transcoder.resample.AudioResampler;
 import com.otaliastudios.transcoder.resample.DefaultAudioResampler;
 import com.otaliastudios.transcoder.sink.DataSink;
@@ -44,6 +46,7 @@ public class TranscoderOptions {
     private TranscoderOptions() {}
 
     private DataSink dataSink;
+    private DecoderIOFactory decoderIOFactory;
     private List<DataSource> videoDataSources;
     private List<DataSource> audioDataSources;
     private TrackStrategy audioTrackStrategy;
@@ -60,6 +63,11 @@ public class TranscoderOptions {
     @NonNull
     public DataSink getDataSink() {
         return dataSink;
+    }
+
+    @NonNull
+    public DecoderIOFactory getDecoderIOFactory() {
+        return decoderIOFactory;
     }
 
     @NonNull
@@ -108,6 +116,7 @@ public class TranscoderOptions {
 
     public static class Builder {
         private DataSink dataSink;
+        private DecoderIOFactory decoderIOFactory;
         private final List<DataSource> audioDataSources = new ArrayList<>();
         private final List<DataSource> videoDataSources = new ArrayList<>();
         private TranscoderListener listener;
@@ -396,11 +405,16 @@ public class TranscoderOptions {
             if (audioResampler == null) {
                 audioResampler = new DefaultAudioResampler();
             }
+            if (decoderIOFactory == null) {
+                decoderIOFactory = new DefaultDecoderIOFactory();
+            }
+
             TranscoderOptions options = new TranscoderOptions();
             options.listener = listener;
             options.audioDataSources = buildAudioDataSources();
             options.videoDataSources = videoDataSources;
             options.dataSink = dataSink;
+            options.decoderIOFactory = decoderIOFactory;
             options.listenerHandler = listenerHandler;
             options.audioTrackStrategy = audioTrackStrategy;
             options.videoTrackStrategy = videoTrackStrategy;

--- a/lib/src/main/java/com/otaliastudios/transcoder/engine/Engine.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/engine/Engine.java
@@ -170,6 +170,7 @@ public class Engine {
                 switch (type) {
                     case VIDEO:
                         transcoder = new VideoTrackTranscoder(dataSource, mDataSink,
+                                options.getDecoderIOFactory(),
                                 interpolator,
                                 options.getVideoRotation());
                         break;

--- a/lib/src/main/java/com/otaliastudios/transcoder/io_factory/DecoderIOFactory.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/io_factory/DecoderIOFactory.java
@@ -1,0 +1,13 @@
+package com.otaliastudios.transcoder.io_factory;
+
+import android.view.Surface;
+
+import com.otaliastudios.transcoder.transcode.base.VideoDecoderOutputBase;
+import com.otaliastudios.transcoder.transcode.base.VideoEncoderInputBase;
+
+import org.jetbrains.annotations.NotNull;
+
+public interface DecoderIOFactory {
+    @NotNull VideoEncoderInputBase createVideoInput(@NotNull Surface surface);
+    @NotNull VideoDecoderOutputBase createVideoOutput();
+}

--- a/lib/src/main/java/com/otaliastudios/transcoder/io_factory/DefaultDecoderIOFactory.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/io_factory/DefaultDecoderIOFactory.java
@@ -1,0 +1,24 @@
+package com.otaliastudios.transcoder.io_factory;
+
+import android.view.Surface;
+
+import com.otaliastudios.transcoder.transcode.internal.VideoDecoderOutput;
+import com.otaliastudios.transcoder.transcode.internal.VideoEncoderInput;
+import com.otaliastudios.transcoder.transcode.base.VideoDecoderOutputBase;
+import com.otaliastudios.transcoder.transcode.base.VideoEncoderInputBase;
+
+import org.jetbrains.annotations.NotNull;
+
+public class DefaultDecoderIOFactory implements DecoderIOFactory {
+    @NotNull
+    @Override
+    public VideoEncoderInputBase createVideoInput(@NotNull Surface surface) {
+        return new VideoEncoderInput(surface);
+    }
+
+    @NotNull
+    @Override
+    public VideoDecoderOutputBase createVideoOutput() {
+        return new VideoDecoderOutput();
+    }
+}

--- a/lib/src/main/java/com/otaliastudios/transcoder/strategy/DefaultVideoStrategy.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/strategy/DefaultVideoStrategy.java
@@ -48,6 +48,21 @@ public class DefaultVideoStrategy implements TrackStrategy {
         private int targetFrameRate;
         private float targetKeyFrameInterval;
         private String targetMimeType;
+        private boolean allowPassThrough;
+    }
+
+
+    /**
+     * Creates a new {@link Builder} with an {@link Resizer}
+     * using given dimensions.
+     *
+     * @param resizer first resizer
+     * @return a strategy builder
+     */
+    @NonNull
+    @SuppressWarnings("WeakerAccess")
+    public static Builder resizer(Resizer resizer) {
+        return new Builder(resizer);
     }
 
     /**
@@ -123,7 +138,7 @@ public class DefaultVideoStrategy implements TrackStrategy {
         private long targetBitRate = BITRATE_UNKNOWN;
         private float targetKeyFrameInterval = DEFAULT_KEY_FRAME_INTERVAL;
         private String targetMimeType = MediaFormatConstants.MIMETYPE_VIDEO_AVC;
-
+        private boolean allowPassThrough = true;
         @SuppressWarnings("unused")
         public Builder() { }
 
@@ -189,6 +204,13 @@ public class DefaultVideoStrategy implements TrackStrategy {
             return this;
         }
 
+        @SuppressWarnings("unused")
+        @NonNull
+        public Builder allowPassThrough(boolean allowPassThrough) {
+            this.allowPassThrough = allowPassThrough;
+            return this;
+        }
+
         @NonNull
         @SuppressWarnings("WeakerAccess")
         public Options options() {
@@ -198,6 +220,7 @@ public class DefaultVideoStrategy implements TrackStrategy {
             options.targetBitRate = targetBitRate;
             options.targetKeyFrameInterval = targetKeyFrameInterval;
             options.targetMimeType = targetMimeType;
+            options.allowPassThrough = allowPassThrough;
             return options;
         }
 
@@ -264,7 +287,7 @@ public class DefaultVideoStrategy implements TrackStrategy {
         // or, for example, each part would be copied into output with its own size,
         // breaking the muxer.
         boolean canPassThrough = inputFormats.size() == 1;
-        if (canPassThrough && typeDone && sizeDone && frameRateDone && frameIntervalDone) {
+        if (options.allowPassThrough && canPassThrough && typeDone && sizeDone && frameRateDone && frameIntervalDone) {
             LOG.i("Input minSize: " + inSize.getMinor() + ", desired minSize: " + outSize.getMinor() +
                     "\nInput frameRate: " + inputFrameRate + ", desired frameRate: " + outFrameRate +
                     "\nInput iFrameInterval: " + inputIFrameInterval + ", desired iFrameInterval: " + options.targetKeyFrameInterval);

--- a/lib/src/main/java/com/otaliastudios/transcoder/transcode/base/VideoDecoderOutputBase.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/transcode/base/VideoDecoderOutputBase.java
@@ -1,0 +1,37 @@
+package com.otaliastudios.transcoder.transcode.base;
+
+import android.media.MediaFormat;
+import android.view.Surface;
+
+import androidx.annotation.NonNull;
+
+public interface VideoDecoderOutputBase {
+
+
+    /**
+     * Configures rotation and scale for given formats.
+     * @param inputFormat input format
+     * @param outputFormat output format
+     * @param sourceRotation source rotation
+     * @param extraRotation extra rotation
+     */
+    void configureWith(@NonNull MediaFormat inputFormat, @NonNull MediaFormat outputFormat, int sourceRotation, int extraRotation);
+
+
+    /**
+     * Returns a Surface to draw onto.
+     * @return the output surface
+     */
+    Surface getSurface();
+
+    /**
+     * Waits for a new frame drawn into our surface (see {@link #getSurface()}),
+     * then draws it using OpenGL.
+     */
+    void drawFrame();
+
+    /**
+     * Discard all resources held by this class, notably the EGL context.
+     */
+    void release();
+}

--- a/lib/src/main/java/com/otaliastudios/transcoder/transcode/base/VideoEncoderInputBase.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/transcode/base/VideoEncoderInputBase.java
@@ -1,0 +1,6 @@
+package com.otaliastudios.transcoder.transcode.base;
+
+public interface VideoEncoderInputBase {
+    void onFrame(long presentationTimeUs);
+    void release();
+}

--- a/lib/src/main/java/com/otaliastudios/transcoder/transcode/internal/VideoEncoderInput.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/transcode/internal/VideoEncoderInput.java
@@ -9,6 +9,7 @@ import androidx.annotation.NonNull;
 
 import com.otaliastudios.opengl.core.EglCore;
 import com.otaliastudios.opengl.surface.EglWindowSurface;
+import com.otaliastudios.transcoder.transcode.base.VideoEncoderInputBase;
 
 /**
  * The purpose of this class is basically doing OpenGL initialization.
@@ -19,7 +20,7 @@ import com.otaliastudios.opengl.surface.EglWindowSurface;
  * Calls to {@link #onFrame(long)} cause a frame of data to be sent to the surface, thus
  * to the {@link android.media.MediaCodec} input.
  */
-public class VideoEncoderInput {
+public class VideoEncoderInput implements VideoEncoderInputBase {
     @SuppressWarnings("unused")
     private static final String TAG = VideoEncoderInput.class.getSimpleName();
 
@@ -37,11 +38,13 @@ public class VideoEncoderInput {
         mEglSurface.makeCurrent();
     }
 
+    @Override
     public void onFrame(long presentationTimeUs) {
         mEglSurface.setPresentationTime(presentationTimeUs * 1000L);
         mEglSurface.swapBuffers();
     }
 
+    @Override
     public void release() {
         // NOTE: Original code calls android.view.Surface.release()
         // after the egl core releasing. This should not be an issue.


### PR DESCRIPTION
Instance creation of **VideoEncoderInput** and **VideoDecoderOutput** are moved to **DecoderIOFactory** which gives ability  to override default **VideoDecoderOutput** and apply custom frame post processing.
By default **DefaultDecoderIOFactory** is used.

Example of configure:
`transcoder.into(file.path).addDataSource(context, uri).setDecoderIOFactory(new TranscoderFilterFactory(filter))`
TranscoderFilterFactory is my custom factory class


