### PR TITLE
Fix: Video joining fails on Android 11

### DIFF
--- a/lib/src/main/java/com/otaliastudios/transcoder/transcode/BaseTrackTranscoder.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/transcode/BaseTrackTranscoder.java
@@ -278,7 +278,8 @@ public abstract class BaseTrackTranscoder implements TrackTranscoder {
 
         if ((mBufferInfo.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
             mIsEncoderEOS = true;
-            mBufferInfo.set(0, 0, 0, mBufferInfo.flags);
+            mEncoder.releaseOutputBuffer(result, false);
+            return DRAIN_STATE_NONE;
         }
         if ((mBufferInfo.flags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0) {
             // SPS or PPS, which should be passed by MediaFormat.

--- a/lib/src/main/java/com/otaliastudios/transcoder/transcode/PassThroughTrackTranscoder.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/transcode/PassThroughTrackTranscoder.java
@@ -69,8 +69,6 @@ public class PassThroughTrackTranscoder implements TrackTranscoder {
         }
         if (mDataSource.isDrained() || forceInputEos) {
             mDataChunk.buffer.clear();
-            mBufferInfo.set(0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM);
-            mDataSink.writeTrack(mTrackType, mDataChunk.buffer, mBufferInfo);
             mIsEOS = true;
             return true;
         }


### PR DESCRIPTION
See **issue** #107 

Starting with Android 11 (tested on the emulator x86_64 and Pixel 2) apparently `MediaMuxer` is automatically stopped in the native code when receiving empty "End of stream" buffer.

Therefore, when joining multiple clips the mixer gets stoped after receiving the last buffer of the first file. After it can't receive any more data and fails with 
`E/MediaAdapter: pushBuffer called before start` 
and then 
` java.lang.IllegalStateException: writeSampleData returned an error`

**Solution:** Don't feed "End of stream" buffers io the muxer.

Thank you, appreciate any feedback 😁