### PR TITLE
Fix when it is not buffer.hasRemaining（refs #144 #153）

### DIFF
--- a/lib/src/main/java/com/otaliastudios/transcoder/internal/audio/chunks.kt
+++ b/lib/src/main/java/com/otaliastudios/transcoder/internal/audio/chunks.kt
@@ -25,8 +25,9 @@ internal class ChunkQueue(private val sampleRate: Int, private val channels: Int
     fun isEmpty() = queue.isEmpty()
 
     fun enqueue(buffer: ShortBuffer, timeUs: Long, timeStretch: Double, release: () -> Unit) {
-        require(buffer.hasRemaining())
-        queue.addLast(Chunk(buffer, timeUs, timeStretch, release))
+        if (buffer.hasRemaining()) {
+            queue.addLast(Chunk(buffer, timeUs, timeStretch, release))
+        }
     }
 
     fun enqueueEos() {


### PR DESCRIPTION
There was a case where `buffer.isremining()` was false when used with `AudioEngine`.
When I debugged, the capacity of buffer was 0.

![スクリーンショット 2021-12-22 20 49 19](https://user-images.githubusercontent.com/2928633/147205149-c147b90c-2a4d-49fe-a872-e82027681b0f.png)

refs: #144 #153