### PR TITLE
fix FilePathDataSource crash before initialize.

### DIFF
--- a/lib/src/main/java/com/otaliastudios/transcoder/source/DataSourceWrapper.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/source/DataSourceWrapper.java
@@ -96,13 +96,16 @@ public class DataSourceWrapper implements DataSource {
 
     @Override
     public boolean isInitialized() {
-        return mSource.isInitialized();
+        return mSource != null && mSource.isInitialized();
     }
 
     @Override
     public void initialize() {
         // Make it easier for subclasses to put their logic in initialize safely.
-        if (!mSource.isInitialized()) {
+        if (!isInitialized()) {
+            if (mSource == null) {
+                throw new NullPointerException("DataSourceWrapper's source is not set!");
+            }
             mSource.initialize();
         }
     }


### PR DESCRIPTION
I'm experienced bug about FilePathDataSource on varsion 0.10.4:
- use `addDataSource(filePath)`
- start `transcode()`
- `DataSources.init()` calls `FilePathDataSource.isInitialized()`
- `DataSourceWrapper.isInitialized` does not check null of `mSource`.
