### PR TITLE
Chunking: Honor buffer.hasRemaining() and otherwise release the buffer.

### DIFF
--- a/lib/src/main/java/com/otaliastudios/transcoder/internal/audio/chunks.kt
+++ b/lib/src/main/java/com/otaliastudios/transcoder/internal/audio/chunks.kt
@@ -25,8 +25,11 @@ internal class ChunkQueue(private val sampleRate: Int, private val channels: Int
     fun isEmpty() = queue.isEmpty()
 
     fun enqueue(buffer: ShortBuffer, timeUs: Long, timeStretch: Double, release: () -> Unit) {
-        require(buffer.hasRemaining())
-        queue.addLast(Chunk(buffer, timeUs, timeStretch, release))
+        if (buffer.hasRemaining()) {
+            queue.addLast(Chunk(buffer, timeUs, timeStretch, release))
+        } else {
+            release()
+        }
     }
 
     fun enqueueEos() {


### PR DESCRIPTION
Fixes #158, #144 & #136

I've verified the fix with a video that without the changes would not transcode but now does.